### PR TITLE
Signature related fixes

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "yNFd2x8a+zFgM4l1lrRaJTR+iL1P5NYrgrtY+QxAuj4=",
+    "shasum": "VlAlhL0qF3C0dPaOWppU0JtqFIEekj4X3wTKmVOv5nY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.tsx
+++ b/packages/snap/src/keyring.tsx
@@ -274,20 +274,14 @@ export class CustodialKeyring implements Keyring {
         ).getSignedMessageLink(custodianId)) as CustodianDeepLink;
       }
     } catch (error) {
-      deepLink = {
-        text: 'Complete in Custodian App',
-        id: custodianId,
-        url: '',
-        action: 'view',
-      };
       console.error('Error getting deep link', error);
     }
 
     return {
       pending: true,
       redirect: {
-        message: deepLink.text,
-        url: deepLink.url,
+        message: deepLink?.text ?? 'Complete in Custodian App',
+        ...(deepLink?.url ? { url: deepLink.url } : {}),
       },
     };
   }


### PR DESCRIPTION
- Don't validate the transaction if it is published by the custodian
- Use default values for the deeplink (because some custodians do not create deeplinks)