### PR TITLE
chore: dont poll requests if the client is locked

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "gmrs64oSJvzFljwbXMqZIW7HGlmPaECfY1sqo+ItKgk=",
+    "shasum": "61twpj95F7b92y4usr2OoZeGh/KO9tpG5GgWfQjy+G0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/snap-state-manager/snap-util.test.ts
+++ b/packages/snap/src/snap-state-manager/snap-util.test.ts
@@ -1,0 +1,108 @@
+import { jest } from '@jest/globals';
+
+import { getStateData, setStateData, getClientStatus } from './snap-util';
+
+// Mock the global snap object
+const mockSnap = {
+  request: jest.fn<(...args: any[]) => Promise<any>>(),
+};
+
+(global as any).snap = mockSnap;
+
+describe('snap-util', () => {
+  beforeEach(() => {
+    // Clear mock calls between tests
+    jest.clearAllMocks();
+  });
+
+  describe('getStateData', () => {
+    it('should retrieve snap state successfully', async () => {
+      const mockState = { foo: 'bar' } as any;
+      mockSnap.request.mockResolvedValueOnce(mockState);
+
+      const result = await getStateData(false);
+
+      expect(result).toStrictEqual(mockState);
+      expect(mockSnap.request).toHaveBeenCalledWith({
+        method: 'snap_manageState',
+        params: { operation: 'get', encrypted: false },
+      });
+    });
+
+    it('should return null when no state exists', async () => {
+      mockSnap.request.mockResolvedValueOnce(null);
+
+      const result = await getStateData(false);
+
+      expect(result).toBeNull();
+      expect(mockSnap.request).toHaveBeenCalledWith({
+        method: 'snap_manageState',
+        params: { operation: 'get', encrypted: false },
+      });
+    });
+
+    it('should throw error when snap request fails', async () => {
+      const error = new Error('Failed to get state');
+      mockSnap.request.mockRejectedValueOnce(error);
+
+      await expect(getStateData(false)).rejects.toThrow('Failed to get state');
+    });
+  });
+
+  describe('setStateData', () => {
+    it('should set snap state successfully', async () => {
+      const newState = { foo: 'bar' };
+      mockSnap.request.mockResolvedValueOnce(undefined);
+
+      await setStateData({ data: newState, encrypted: false });
+
+      expect(mockSnap.request).toHaveBeenCalledWith({
+        method: 'snap_manageState',
+        params: {
+          operation: 'update',
+          newState,
+          encrypted: false,
+        },
+      });
+    });
+
+    it('should throw error when snap request fails', async () => {
+      const newState = { foo: 'bar' };
+      const error = new Error('Failed to set state');
+      mockSnap.request.mockRejectedValueOnce(error);
+
+      await expect(
+        setStateData({ data: newState, encrypted: false }),
+      ).rejects.toThrow('Failed to set state');
+    });
+
+    it('should handle setting null state', async () => {
+      mockSnap.request.mockResolvedValueOnce(undefined);
+
+      await setStateData({ data: null, encrypted: false });
+
+      expect(mockSnap.request).toHaveBeenCalledWith({
+        method: 'snap_manageState',
+        params: {
+          operation: 'update',
+          newState: null,
+          encrypted: false,
+        },
+      });
+    });
+  });
+
+  describe('getClientStatus', () => {
+    it('should retrieve client status successfully', async () => {
+      const mockStatus = { locked: true };
+      mockSnap.request.mockResolvedValueOnce(mockStatus);
+
+      const result = await getClientStatus();
+
+      expect(result).toStrictEqual(mockStatus);
+      expect(mockSnap.request).toHaveBeenCalledWith({
+        method: 'snap_getClientStatus',
+      });
+    });
+  });
+});

--- a/packages/snap/src/snap-state-manager/snap-util.ts
+++ b/packages/snap/src/snap-state-manager/snap-util.ts
@@ -1,4 +1,4 @@
-import type { Json } from '@metamask/snaps-sdk';
+import type { GetClientStatusResult, Json } from '@metamask/snaps-sdk';
 
 /**
  * Retrieves the current state data.
@@ -37,5 +37,17 @@ export async function setStateData<State>({
       newState: data as unknown as Record<string, Json>,
       encrypted,
     },
+  });
+}
+
+/**
+ * Retrieves the client status (locked/unlocked) in this case from MM.
+ * Used to check if the client is locked or not.
+ *
+ * @returns An object containing the status.
+ */
+export async function getClientStatus(): Promise<GetClientStatusResult> {
+  return await snap.request({
+    method: 'snap_getClientStatus',
   });
 }


### PR DESCRIPTION
### 4.11 Cronjob - Check if MetaMask Is Locked

Description
The cronjob handler calls RequestManager.poll() every 10 seconds. The poll() function access data from encrypted state via stateManager. According to the Snaps API Documentation, encrypted storage cannot be accessed while MetaMask is locked.

Note: The cronjob is running every minute. Due to the clients requirements their Snap polls for updates every 10 seconds. Therefore they install 6 promises every minute (10 seconds apart). This might lead to deferred promises triggering while MetaMask is locked.

```typescript:packages/snap/src/index.ts
export const onCronjob: OnCronjobHandler = async ({ request }) => {
  switch (
    request.method // @audit-info this is execute every minute * * * * *  acc. to manifest
  ) {
    case 'execute': {
      const startTime = Date.now();
      const timeoutDuration = 60000; // 1 minute in milliseconds //@audit will this work with mm snap scheduling?

      // Run pollTransactions 6 times with 10-second intervals
      for (let i = 0; i < 6; i++) {
        // Check if we've exceeded the timeout
        if (Date.now() - startTime >= timeoutDuration) {
          return;
        }

        await pollRequests(); // @audit - what if there is nothing to poll?
        // If this isn't the last iteration, wait 10 seconds
        if (i < 5) {
          await new Promise((resolve) => setTimeout(resolve, 10000)); // @audit-info sleep(10sec)
        }
      }
      return;
    }
```

```typescript:packages/snap/src/requestsManager.ts
async poll(): Promise<void> {
  const pendingRequests = (await this.listRequests()).filter(
    (request) => !request.fulfilled,
  );
```

```typescript:packages/snap/src/requestsManager.ts
async listRequests(): Promise<
  CustodialSnapRequest<SignedMessageRequest | TransactionRequest>[]
> {
  return this.#stateManager.listRequests();
}
```

Recommendation
Inside pollRequests return early, if snap_getClientStatus returns that MetaMask is locked.
