### PR TITLE
chore: fix potential redos finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ node_modules/
 
 # IntelliJ
 .idea/
+
+audit.md

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "gmrs64oSJvzFljwbXMqZIW7HGlmPaECfY1sqo+ItKgk=",
+    "shasum": "2ois1H2a31QS6Hh1R8OdukVrv4B/k3k3qWVm7Q6rFcM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "2ois1H2a31QS6Hh1R8OdukVrv4B/k3k3qWVm7Q6rFcM=",
+    "shasum": "a6vJo/jcrUjQliagkXLuLmucJTS9VadmWEdonw4hGxc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/lib/custodian-types/cactus/CactusCustodianApi.ts
+++ b/packages/snap/src/lib/custodian-types/cactus/CactusCustodianApi.ts
@@ -80,7 +80,7 @@ export class CactusCustodianApi extends EventEmitter implements ICustodianApi {
     }
 
     return accounts.filter((account) =>
-      new RegExp(name, 'u').test(account.name),
+      account.name.toLowerCase().includes(name.toLowerCase()),
     );
   }
 


### PR DESCRIPTION
From the audit

### 4.6 Lib/Cactus - Potential ReDoS in getEthereumAccountsByLabelOrAddressName Minor

Description
The function uses the name parameter directly as a regular expression pattern. If name comes from an untrusted source, like user input or data from a dApp, the function could be vulnerable to a Regular Expression Denial-of-Service (ReDoS) attack. In such a scenario, an attacker might provide input that causes the regular expression engine to take a long time to process, potentially leading to performance issues or service disruption.

Examples
```typescript:packages/snap/src/lib/custodian-types/cactus/CactusCustodianApi.ts
async getEthereumAccountsByLabelOrAddressName(
  name: string,
): Promise<IEthereumAccount<ICactusEthereumAccountCustodianDetails>[]> {
  const accounts = await this.getEthereumAccounts();

  if (!name.length) {
    return accounts;
  }

  return accounts.filter((account) =>
    new RegExp(name, 'u').test(account.name),
  );
}
```

Recommendation
Avoid the regular expressions for this use case. Use accounts -> account.includes() instead. See BitGo implementation.

