### PR TITLE
chore: enforce custodian API URL in production mode

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "zpyeG7xWVjWFQMwvkCAnoUfuAQvhQ0zb3XK6b2KNdi8=",
+    "shasum": "YqqIP4y3SdFEIgIRia6N+ksCrPv+CkypwuXVri5imlM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.tsx
+++ b/packages/snap/src/keyring.tsx
@@ -88,6 +88,26 @@ export class CustodialKeyring implements Keyring {
       (item) => item.apiBaseUrl === options.details.custodianApiUrl,
     );
 
+    let custodianEnvironmentName: string;
+    let custodianEnvironmentDisplayName: string;
+
+    // If dev mode is enabled, trust the custodian info from the onboarding request
+
+    if (config.dev) {
+      custodianEnvironmentName = options.details.custodianEnvironment;
+      custodianEnvironmentDisplayName = options.details.custodianDisplayName;
+    } else {
+      // Otherwise, use the custodian info from the custodian metadata
+      // and if it's not found, throw an error
+      if (!custodian) {
+        throw new Error(
+          `No custodian allowlisted for API URL: ${options.details.custodianApiUrl}`,
+        );
+      }
+      custodianEnvironmentName = custodian.name;
+      custodianEnvironmentDisplayName = options.details.custodianDisplayName;
+    }
+
     const { address, name } = options;
 
     const wallets = await this.#stateManager.listWallets();
@@ -111,7 +131,8 @@ export class CustodialKeyring implements Keyring {
         id: uuid(),
         options: {
           custodian: {
-            displayName: options.details.custodianDisplayName,
+            environmentName: custodianEnvironmentName,
+            displayName: custodianEnvironmentDisplayName,
             deferPublication,
             importOrigin: options.origin,
           },

--- a/packages/snap/src/lib/types/CustodialKeyringAccount.ts
+++ b/packages/snap/src/lib/types/CustodialKeyringAccount.ts
@@ -2,6 +2,7 @@ import type { KeyringAccount } from '@metamask/keyring-api';
 
 export type CustodialKeyringAccountOptions = {
   custodian: {
+    environmentName: string;
     displayName: string;
     deferPublication: boolean;
     importOrigin: string;

--- a/packages/snap/src/stateManagement.test.ts
+++ b/packages/snap/src/stateManagement.test.ts
@@ -27,6 +27,7 @@ describe('KeyringStateManager', () => {
     address: `0x${id}`,
     options: {
       custodian: {
+        environmentName: 'test-custodian',
         displayName: 'Test Custodian',
         deferPublication: false,
         importOrigin: 'test-origin',

--- a/packages/snap/src/util/is-unique-address.test.ts
+++ b/packages/snap/src/util/is-unique-address.test.ts
@@ -16,6 +16,7 @@ describe('isUniqueAddress', () => {
             id: '1',
             options: {
               custodian: {
+                environmentName: 'test-custodian',
                 displayName: 'custodian',
                 deferPublication: false,
                 importOrigin: 'test-origin',


### PR DESCRIPTION
### 4.2 RPC Onboarding - custodianAPIurl Should Be Checked Against custodianMetaData; Origin May Configure Accounts for Other Custodians Medium

Description
The snap maintains a mapping of Custodian Metadata that includes whitelisted API url settings. However, during onboarding, a custodian can provide any API URL to retrieve accounts from.

While clarifying if a custodian should be allowed to provide any API URL the client provided the following feedback:

By design, it's not, because we want to maintain the ability for custodians to create new test environments arbitrarily However, it's something we should enforce when !config.dev

Additionally, there is no enforcement that a specific origin is configuring accounts for their custodian. For example, Cactus may theoretically decide to configure accounts under the Bitgo API URL or with Bitgo details in account objects returned from the external call.

Examples
```typescript:packages/snap/src/index.ts
export const handleOnboarding = async (request: OnBoardingRpcRequest) => {
  assert(request, OnBoardingRpcRequest);

  const CustodianApiClass = CustodianApiMap[request.custodianType];
  const keyring = await getKeyring();

  if (!Object.values(CustodianType).includes(request.custodianType)) {
    throw new Error(`Custodian type ${request.custodianType} not supported`);
  }

  const custodianApi = new CustodianApiClass(
    {
      refreshToken: request.token,
      refreshTokenUrl: request.refreshTokenUrl,
    },
    request.custodianApiUrl,
    1000,
  );
```

```typescript:packages/snap/src/lib/custodian-types/custodianMetadata.ts
export const custodianMetadata: (
  | ECA3CustodianMetadata
  | ECA1CustodianMetadata
  | BitGoCustodianMetadata
  | CactusCustodianMetadata
)[] = [
  {
    refreshTokenUrl: null,
    name: 'bitgo-test',
    displayName: 'BitGo Test',
    production: false,
    apiBaseUrl: 'https://app.bitgo-test.com/defi/v2',
    apiVersion: CustodianType.BitGo,
    custodianPublishesTransaction: true,
    iconUrl:
      'https://dashboard.metamask-institutional.io/custodian-icons/bitgo-icon.svg',
    isManualTokenInputSupported: false,
    onboardingUrl: 'https://app.bitgo-test.com',
    allowedOnboardingDomains: ['app.bitgo-test.com'],
  },
```

```typescript:packages/snap/src/keyring.tsx
async createAccount(
  options: CreateAccountOptions,
): Promise<CustodialKeyringAccount> {
  assert(options, CreateAccountOptions);

  // Try to get the options from the custodian metadata
  const custodian = custodianMetadata.find(
    (item) => item.apiBaseUrl === options.details.custodianApiUrl,
  );
```

Recommendation
Enforce that custodianApiUrl matches the constraints for the API url in custodianMetaData in production mode. Generally enforce that an origin can only configure settings for their namespace.
