### PR TITLE
chore: show errors in the add token form

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "tfA1ASTQH/i3TTZyFkNI1LLbXTjLBgGEoYZ2RhUEwgA=",
+    "shasum": "+d/cxaoCsetFLv5OUM9O3Fm4aP2gR5kB9Xo8lknKuSY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/features/homepage/components/AddToken.tsx
+++ b/packages/snap/src/features/homepage/components/AddToken.tsx
@@ -7,6 +7,7 @@ import {
   Field,
   Input,
   Form,
+  Text,
 } from '@metamask/snaps-sdk/jsx';
 import type { SnapComponent, SnapElement } from '@metamask/snaps-sdk/jsx';
 
@@ -15,10 +16,12 @@ import { HomePageNames, HomePagePrefixes } from '../types';
 
 export type AddTokenProps = {
   custodianName?: string;
+  error?: string;
 };
 
 export const AddToken: SnapComponent<AddTokenProps> = ({
   custodianName,
+  error,
 }: AddTokenProps): SnapElement => {
   if (!custodianName) {
     throw new Error('Custodian name is required');
@@ -41,6 +44,7 @@ export const AddToken: SnapComponent<AddTokenProps> = ({
             <Input name="apiUrl" value={selectedCustodian?.apiBaseUrl} />
           </Field>
         </Form>
+        {error ? <Text>{error}</Text> : null}
       </Box>
       <Footer>
         <Button name={HomePageNames.CancelToken}>Cancel</Button>

--- a/packages/snap/src/features/homepage/events.tsx
+++ b/packages/snap/src/features/homepage/events.tsx
@@ -119,13 +119,16 @@ export async function onRemoveTokenClick({
  * @param options - The options for the event.
  * @param options.id - The id of the interface.
  * @param options.event - The event.
+ * @param options.context - The context for the homepage.
  */
 export async function onConnectTokenClick({
   id,
   event,
+  context,
 }: {
   id: string;
   event: ButtonClickEvent;
+  context: HomePageContext;
 }) {
   const custodianName =
     event.name?.replace(HomePagePrefixes.ConnectToken, '') ?? '';
@@ -150,6 +153,10 @@ export async function onConnectTokenClick({
       custodianApiUrl = selectedCustodian?.apiBaseUrl ?? '';
     }
 
+    if (!token?.length) {
+      throw new Error('Token is required');
+    }
+
     const onboardingRequest: OnBoardingRpcRequest = {
       custodianType: selectedCustodian.apiVersion,
       custodianEnvironment: selectedCustodian.name ?? '',
@@ -163,7 +170,11 @@ export async function onConnectTokenClick({
   } catch (error: unknown) {
     logger.error('Error onboarding', error);
     if (error instanceof Error) {
-      await renderErrorMessage(error.message);
+      await updateInterface(
+        id,
+        <AddToken custodianName={custodianName} error={error.message} />,
+        context,
+      );
     } else {
       await renderErrorMessage('An unknown error occurred');
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dff5ba9e-2528-4f25-ab5e-e972f54c0c92)

Now we show errors in the add token form, rather than using notifications