### PR TITLE
chore: use typed sign v4 where appropriate

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "SQjbdNCPGTDlJebATymzpe1CPlkgTe/m631UxT28WEo=",
+    "shasum": "Cf2ok85SzW/KNWJDMBrulzHVz+T1JeIOI6mBuOlax5Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.tsx
+++ b/packages/snap/src/keyring.tsx
@@ -469,7 +469,7 @@ export class CustodialKeyring implements Keyring {
           from,
           data,
           custodianApi,
-          { version: SignTypedDataVersion.V3 },
+          { version: SignTypedDataVersion.V4 },
         );
         await this.#requestManagerFacade.upsertRequest({
           keyringRequest,


### PR DESCRIPTION
We were using V3 instead of V4, GK8 noticed this