### PR TITLE
Update cubist data for onboarding

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "Dsn1k+zBbtLrfx6VRvsdkdTXy2Db/YQSF82oIc3FheQ=",
+    "shasum": "d8VCfzrB6UmuSdQMRCqt4kgcmDuFdRHFEG1bzWEPt2M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -91,7 +91,10 @@
         "https://pre.mycactus.com",
         "https://www.mycactus.dev",
         "https://debug.mycactus.dev:1443",
-        "https://www.mycactus.com"
+        "https://www.mycactus.com",
+        "https://app-gamma.signer.cubist.dev",
+        "https://app-beta.signer.cubist.dev",
+        "https://app.signer.cubist.dev"
       ]
     },
     "endowment:cronjob": {

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "cRYeHNYrfO1kxdqbF+6d3kBYhi4WpKKFMEkH49V5yts=",
+    "shasum": "Dsn1k+zBbtLrfx6VRvsdkdTXy2Db/YQSF82oIc3FheQ=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -45,7 +45,10 @@
     "https://pre.mycactus.com": {},
     "https://www.mycactus.dev": {},
     "https://debug.mycactus.dev:1443": {},
-    "https://www.mycactus.com": {}
+    "https://www.mycactus.com": {},
+    "https://app-gamma.signer.cubist.dev": {},
+    "https://app-beta.signer.cubist.dev": {},
+    "https://app.signer.cubist.dev": {}
   },
   "initialPermissions": {
     "snap_notify": {},

--- a/packages/snap/src/lib/custodian-types/custodianMetadata.ts
+++ b/packages/snap/src/lib/custodian-types/custodianMetadata.ts
@@ -384,6 +384,19 @@ export const custodianMetadata: (
     allowedOnboardingDomains: ['app-beta.signer.cubist.dev', 'localhost:3000'],
   },
   {
+    refreshTokenUrl: 'https://dg5z0qnzb9s65.cloudfront.net/v0/oauth/token',
+    name: 'cubist-test',
+    displayName: 'Cubist Test',
+    production: false,
+    apiBaseUrl: 'https://dg5z0qnzb9s65.cloudfront.net/v0/mmi',
+    apiVersion: CustodianType.ECA3,
+    custodianPublishesTransaction: false,
+    iconUrl:
+      'https://assets-global.website-files.com/638a2693daaf8527290065a3/651802cf8d04ec5f1a09ce86_Logo.svg',
+    isManualTokenInputSupported: true,
+    allowedOnboardingDomains: [],
+  },
+  {
     refreshTokenUrl: 'https://prod.signer.cubist.dev/v0/oauth/token',
     name: 'cubist-prod',
     displayName: 'Cubist',

--- a/packages/snap/src/lib/custodian-types/custodianMetadata.ts
+++ b/packages/snap/src/lib/custodian-types/custodianMetadata.ts
@@ -368,20 +368,20 @@ export const custodianMetadata: (
     iconUrl:
       'https://assets-global.website-files.com/638a2693daaf8527290065a3/651802cf8d04ec5f1a09ce86_Logo.svg',
     isManualTokenInputSupported: true,
-    allowedOnboardingDomains: [], // Cubist does not support onboarding via a web page
+    allowedOnboardingDomains: ['app-gamma.signer.cubist.dev'],
   },
   {
-    refreshTokenUrl: 'https://dg5z0qnzb9s65.cloudfront.net/v0/oauth/token',
-    name: 'cubist-test',
-    displayName: 'Cubist Test',
+    refreshTokenUrl: 'https://beta.signer.cubist.dev/v0/oauth/token',
+    name: 'cubist-beta',
+    displayName: 'Cubist Beta',
     production: false,
-    apiBaseUrl: 'https://dg5z0qnzb9s65.cloudfront.net/v0/mmi',
+    apiBaseUrl: 'https://beta.signer.cubist.dev/v0/mmi',
     apiVersion: CustodianType.ECA3,
     custodianPublishesTransaction: false,
     iconUrl:
       'https://assets-global.website-files.com/638a2693daaf8527290065a3/651802cf8d04ec5f1a09ce86_Logo.svg',
     isManualTokenInputSupported: true,
-    allowedOnboardingDomains: [], // Cubist does not support onboarding via a web page
+    allowedOnboardingDomains: ['app-beta.signer.cubist.dev', 'localhost:3000'],
   },
   {
     refreshTokenUrl: 'https://prod.signer.cubist.dev/v0/oauth/token',
@@ -394,7 +394,7 @@ export const custodianMetadata: (
     iconUrl:
       'https://assets-global.website-files.com/638a2693daaf8527290065a3/651802cf8d04ec5f1a09ce86_Logo.svg',
     isManualTokenInputSupported: true,
-    allowedOnboardingDomains: [], // Cubist does not support onboarding via a web page
+    allowedOnboardingDomains: ['app.signer.cubist.dev'],
   },
   {
     refreshTokenUrl: 'http://localhost:3330/oauth/token',


### PR DESCRIPTION
We're going enable onboarding in our webapp so we need to update the extension metadata. While I was in there I removed the test endpoint we used when initially setting up token refresh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Snap’s origin allowlists and custodian metadata to permit Cubist web-based onboarding; incorrect domain configuration could unintentionally broaden which sites can interact with the Snap.
> 
> **Overview**
> Enables Cubist webapp onboarding by expanding the Snap manifest’s `initialConnections` / RPC `allowedOrigins` to include the Cubist Gamma, Beta, and Prod signer app domains.
> 
> Updates Cubist custodian metadata to add a new `cubist-beta` entry and to set `allowedOnboardingDomains` for `cubist-gamma` and `cubist-prod` (instead of empty lists), aligning onboarding checks with the new web domains. Also updates the manifest `source.shasum` to match the rebuilt bundle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e6ceeb9662dd8ec6d04ff55435eee9be9ee5f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->