### PR TITLE
chore: revert failed 2.0.0 / 2.0.1 release bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-institutional-wallet",
-  "version": "2.0.0",
+  "version": "1.5.0",
   "description": "Institutional accounts in MetaMask",
   "keywords": [
     "metamask",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-institutional-wallet",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Institutional accounts in MetaMask",
   "keywords": [
     "metamask",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
 ## [1.0.0]
 
 ### Changed
-
 - Audit remediation fixes ([#37](https://github.com/MetaMask/snap-institutional-wallet/pull/37))
+
+### Changed
+
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.0.0...v2.0.0
-[1.0.0]: https://github.com/MetaMask/snap-institutional-wallet/releases/tag/v1.0.0
+[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.3.1...v1.0.0
+[0.3.1]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.2.10...v0.3.0
+[0.2.10]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.2.9...v0.2.10
+[0.2.9]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.2.8...v0.2.9
+[0.2.8]: https://github.com/MetaMask/snap-institutional-wallet/releases/tag/v0.2.8

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/institutional-wallet-api",
   "private": true,
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Example custodian API",
   "packageManager": "yarn@3.6.3",
   "dependencies": {

--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
 ## [1.0.0]
+
 
 ## [0.3.1]
 
@@ -29,8 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.0.0...v2.0.0
+[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.3.1...v1.0.0
 [0.3.1]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v0.2.10...v0.3.0

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/insitutional-wallet-site",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": true,
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,109 +6,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
-### Changed
-
-- Upgrade to keyring API v23 / snaps-sdk 11.2 and require Node 20 ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-- Allow MetaMask origins to call `keyring_setSelectedAccounts` ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-- Re-selecting an already-imported account refreshes its custodian credentials instead of failing ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-- Persist development mode in unencrypted snap state so permissions work while the client is locked ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-
-### Fixed
-
-- Throw `UnauthorizedError` for denied keyring requests so callers get a JSON-RPC error instead of a snap crash ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-- Keep homepage interface context in sync when toggling development mode ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-
-### Removed
-
-- Remove BitGo, Cactus, and other legacy MMI custodian integrations and their manifest origins ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-
 ## [1.5.0]
-
 ### Uncategorized
-
 - chore: update snap version
 - 1.5.0
 
 ### Changed
-
 - Update cubist data for onboarding ([#72](https://github.com/MetaMask/snap-institutional-wallet/pull/72))
 
 ## [1.3.4]
-
 ### Fixed
-
 - Handle the case where the refresh token changes during onboarding (e.g. cubist) ([#70](https://github.com/MetaMask/snap-institutional-wallet/pull/70))
 
 ## [1.3.3]
-
 ### Changed
-
 - chore: disable old MMI custodians, add cubist prod ([#68](https://github.com/MetaMask/snap-institutional-wallet/pull/68))
 - chore: use typed sign v4 where appropriate ([#66](https://github.com/MetaMask/snap-institutional-wallet/pull/66))
 
 ## [1.3.2]
-
 ### Added
-
 - chore: enable fireblocks sandboxes in prod mode, but hide ([#64](https://github.com/MetaMask/snap-institutional-wallet/pull/64))
 
 ## [1.3.1]
-
 ### Fixed
-
 - Fix bugs with dev mode ([#62](https://github.com/MetaMask/snap-institutional-wallet/pull/62))
 
 ## [1.3.0]
-
 ### Added
-
 - Add dev mode toggle to the homepage ([#59](https://github.com/MetaMask/snap-institutional-wallet/pull/59))- feat(dev-mode-toggle): allow users to toggle developer mode ([#59](https://github.com/MetaMask/snap-institutional-wallet/pull/59))
 
 ### Changed
-
 - chore: show errors in the add token form ([#60](https://github.com/MetaMask/snap-institutional-wallet/pull/60))
 
 ## [1.2.1]
-
 ### Changed
-
 - Add `authentication.getIsSupported` RPC method ([#57](https://github.com/MetaMask/snap-institutional-wallet/pull/57))
 
 ### Fixed
-
 - Remove log in permissions.ts ([#56](https://github.com/MetaMask/snap-institutional-wallet/pull/56))
 
 ## [1.2.0]
-
 ### Changed
-
 - Remove old hacky cronjob implementation ([#54](https://github.com/MetaMask/snap-institutional-wallet/pull/54))
 - Implement "deep sleep" mechanism until the snap is used for the first time ([#54](https://github.com/MetaMask/snap-institutional-wallet/pull/54))
 - Set `displayAccountNameSuggestion` to `false` ([#54](https://github.com/MetaMask/snap-institutional-wallet/pull/54))
 
 ## [1.1.1]
-
 ### Changed
-
 - Move all dependencies to devdependencies and alphabetise ([#52](https://github.com/MetaMask/snap-institutional-wallet/pull/52))
 
 ## [1.1.0]
-
 ### Changed
-
 - Enforce custodian API URL in production mode ([#49](https://github.com/MetaMask/snap-institutional-wallet/pull/49))
 - Pin dependencies ([#48](https://github.com/MetaMask/snap-institutional-wallet/pull/48))
 
 ### Fixed
-
 - Fix get signed message with cactus ([#50](https://github.com/MetaMask/snap-institutional-wallet/pull/50))
 
 ## [1.0.0]
-
 ### Changed
-
 - Show account creation errors to the user ([#46](https://github.com/MetaMask/snap-institutional-wallet/pull/46))
 - Explicitly check if a method is suppported for an account ([#45](https://github.com/MetaMask/snap-institutional-wallet/pull/45))
 - Fix potential redos finding ([#44](https://github.com/MetaMask/snap-institutional-wallet/pull/44))
@@ -120,38 +75,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add tests for keyring.ts ([#36](https://github.com/MetaMask/snap-institutional-wallet/pull/36))
 
 ## [0.3.1]
-
 ### Changed
-
 - Fix custodian permissions ([#34](https://github.com/MetaMask/snap-institutional-wallet/pull/34))
 
 ## [0.3.0]
-
 ### Changed
-
 - chore: Adjust permissions and refactor checks to support bitgo ([#32](https://github.com/MetaMask/snap-institutional-wallet/pull/32))
 - chore: Audit remediation ([#31](https://github.com/MetaMask/snap-institutional-wallet/pull/31))
 
 ## [0.2.10]
-
 ### Removed
-
 - chore: remove saturn and neptune dev ([#29](https://github.com/MetaMask/snap-institutional-wallet/pull/29))
 
 ## [0.2.9]
-
 ### Changed
-
 - chore: add zodia UI URLs to allowlist ([#27](https://github.com/MetaMask/snap-institutional-wallet/pull/27))
 
 ## [0.2.8]
-
 ### Changed
-
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.5.0...v2.0.0
+[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.5.0...HEAD
 [1.5.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.3.4...v1.5.0
 [1.3.4]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.3.2...v1.3.3

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1]
-
-### Fixed
-
-- Build releases on Node 20, which the 2.0.0 toolchain requires, so the snap can be published ([#76](https://github.com/MetaMask/snap-institutional-wallet/pull/76))
-- No functional changes since 2.0.0, which was tagged but never published, so this is the first release carrying the changes listed under 2.0.0 below
-
 ## [2.0.0]
 
 ### Changed
@@ -23,14 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-selecting an already-imported account refreshes its custodian credentials instead of failing ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
 - Persist development mode in unencrypted snap state so permissions work while the client is locked ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
 
-### Removed
-
-- Remove BitGo, Cactus, and other legacy MMI custodian integrations and their manifest origins ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
-
 ### Fixed
 
 - Throw `UnauthorizedError` for denied keyring requests so callers get a JSON-RPC error instead of a snap crash ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
 - Keep homepage interface context in sync when toggling development mode ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
+
+### Removed
+
+- Remove BitGo, Cactus, and other legacy MMI custodian integrations and their manifest origins ([#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74))
 
 ## [1.5.0]
 
@@ -157,8 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v2.0.1...HEAD
-[2.0.1]: https://github.com/MetaMask/snap-institutional-wallet/compare/v2.0.0...v2.0.1
+[Unreleased]: https://github.com/MetaMask/snap-institutional-wallet/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.5.0...v2.0.0
 [1.5.0]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.3.4...v1.5.0
 [1.3.4]: https://github.com/MetaMask/snap-institutional-wallet/compare/v1.3.3...v1.3.4

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/institutional-wallet-snap",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Institutional accounts in MetaMask.",
   "keywords": [
     "metamask",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/institutional-wallet-snap",
-  "version": "2.0.0",
+  "version": "1.5.0",
   "description": "Institutional accounts in MetaMask.",
   "keywords": [
     "metamask",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Institutional accounts in MetaMask.",
   "proposedName": "Institutional Wallet",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "MHAdClnzJEfoGk8Mdye0lqV06QCnb3dG8f7DWLxpEa4=",
+    "shasum": "ukR3VPpyBm/dX2uasoUj5UQxV/0VzBpG+NtYJrVgS8M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "1.5.0",
   "description": "Institutional accounts in MetaMask.",
   "proposedName": "Institutional Wallet",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-institutional-wallet.git"
   },
   "source": {
-    "shasum": "ukR3VPpyBm/dX2uasoUj5UQxV/0VzBpG+NtYJrVgS8M=",
+    "shasum": "/CCzo011U8l1duu13B+KFIpmPHLtgN7eR46sAcZBV/M=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
## Summary

- Reverts [#77](https://github.com/MetaMask/snap-institutional-wallet/pull/77) (`2.0.1`)
- Reverts [#75](https://github.com/MetaMask/snap-institutional-wallet/pull/75) (`2.0.0`)
- **Keeps** [#74](https://github.com/MetaMask/snap-institutional-wallet/pull/74) (the actual 2.0.0 product work)
- **Keeps** [#76](https://github.com/MetaMask/snap-institutional-wallet/pull/76) (Node 20 CI fix needed to publish)


